### PR TITLE
 Upd gitignore + dont return unknown language 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 composer.lock
 .DS_Store
 build/logs/*
+.idea

--- a/src/Lingua/ComponentConverter.php
+++ b/src/Lingua/ComponentConverter.php
@@ -4,11 +4,18 @@ namespace WhiteCube\Lingua;
 
 class ComponentConverter extends Converter
 {
+    /**
+     * @return string
+     */
     public function __toString()
     {
         return $this->original['full'];
     }
 
+    /**
+     * @param $format
+     * @return bool
+     */
     public static function check($format)
     {
         if(!is_array($format)) $format = static::prepare($format);
@@ -16,9 +23,15 @@ class ComponentConverter extends Converter
         return false;
     }
 
+    /**
+     * @throws \Exception
+     */
     public function parse()
     {
         $this->repository = $this->findInRepository();
+        if ($this->repository) {
+            throw new \Exception('Language is not in our repository');
+        }
         $this->fillNameBag('script', 'scripts');
         $this->fillNameBag('country', 'countries');
         $this->iso_639_1 = $this->getIsoValue('iso-639-1');


### PR DESCRIPTION
I am using the library to check if a language really exists and then format it to the format I want.

The problem is that, without the exception the converter still returns something for zh-kt for example even if it doesn't exist ! Why returning that whereas we have a strong repository with a lot of countries informations in it ?

At least if this PR is not accepted, put a parameter like "isValid" or something