### PR TITLE
Support for PHP8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 .DS_Store
 build/logs/*
 .idea
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - '7.0'
   - '7.1'
+  - '8.0'
 
 env:
   global:

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "whitecube/lingua",
-    "description": "A PHP-7 language codes converter, from and to the most common formats (ISO, W3C, PHP and human-readable names).",
+    "description": "A PHP language codes converter, from and to the most common formats (ISO, W3C, PHP and human-readable names).",
     "keywords": ["localization", "locales", "language", "conversion", "ISO", "codes", "BCP-47", "translation", "translate"],
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -26,12 +26,11 @@
         "source": "https://github.com/whiteCube/lingua"
     },
     "require": {
-        "php": "^7.0",
+        "php": "^7.0|^8.0",
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.1",
-        "codeclimate/php-test-reporter": "dev-master"
+        "phpunit/phpunit": "^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,28 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         bootstrap="vendor/autoload.php"
+<phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  colors="true"
+  bootstrap="vendor/autoload.php"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
 >
-
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml" />
-    </logging>
-
-    <filter>
-        <whitelist>
-            <directory>src/Lingua</directory>
-        </whitelist>
-    </filter>
-
-    <testsuites>
-        <testsuite name="Lingua Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
+  <coverage>
+    <include>
+      <directory>src/Lingua</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <logging/>
+  <testsuites>
+    <testsuite name="Lingua Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/LanguagesRepositoryTest.php
+++ b/tests/LanguagesRepositoryTest.php
@@ -8,7 +8,7 @@ class LanguageRespositoryTest extends TestCase
 {
     protected $buffer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->buffer = file_get_contents('./languages.php');
     }
@@ -28,7 +28,7 @@ class LanguageRespositoryTest extends TestCase
         $this->assertEquals('whi', Lingua::createFromName('whitecube')->toISO_639_3());
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         file_put_contents('./languages.php', $this->buffer);
     }


### PR DESCRIPTION
Fixes #5

I did PoC and tested in my PHP8 project, seems to be working. But I only used `Lingua::create('...')->toW3C();` so I don't know if everything works properly (tests are green).

If it's acceptable, please release new version after merging.