### PR TITLE
Fix repository path that cannot be loaded within PHAR archive

### DIFF
--- a/src/Lingua/LanguagesRepository.php
+++ b/src/Lingua/LanguagesRepository.php
@@ -13,7 +13,7 @@ class LanguagesRepository
 
     public function __construct()
     {
-        $this->path = realpath(__DIR__ . '/../../languages.php');
+        $this->path = __DIR__ . '/../../languages.php';
         $this->languages = $this->loadRepository();
     }
 
@@ -56,7 +56,7 @@ class LanguagesRepository
 
     protected function loadRepository()
     {
-        if(!$this->path) {
+        if(false === @file_get_contents($this->path)) {
             throw new \Exception('Lingua\'s languages repository could not be loaded');
         }
         return include($this->path);


### PR DESCRIPTION
Hello, in order to make the lib work while included in a PHAR file, I had to prevent usage of the `realpath` function that cannot resolve the magic method `__DIR__` (it will return false).
Instead I suggest using the `file_get_contents` method that can resolve the `phar://` scheme returned by `__DIR__`.